### PR TITLE
Updated manual approval job as per latest spec for custom jobs

### DIFF
--- a/custom-job.yml
+++ b/custom-job.yml
@@ -78,7 +78,7 @@ handlers:
     env: 
       API_TOKEN: ${{ cloudbees.api.token }}
       URL: ${{ cloudbees.api.url }}
-      PAYLOAD: ${{ handler.callback.payload }}
+      PAYLOAD: ${{ handler.payload }}
   
   cancel:
     uses: docker://alpine:latest
@@ -92,21 +92,7 @@ handlers:
       then
         echo "Platform API call failed with error: '$response'"
 
-        # Save failure
-        echo '{    
-          "status": "FAILED",
-          "message": "Failed to change workflow manual approval status with error: '$response'"
-        }' > $CLOUDBEES_CUSTOM_JOB_STATUS
-      
-        exit 1
-      fi
-
-      # Save success
-      echo '{    
-        "status": "$CANCELLATION_REASON",
-        "message": "Successfully changed workflow manual approval status to '$CANCELLATION_REASON'"
-      }' > $CLOUDBEES_CUSTOM_JOB_STATUS
-    env: 
+    env:
       API_TOKEN: ${{ cloudbees.api.token }}
       URL: ${{ cloudbees.api.url }}
-      CANCELLATION_REASON: ${{ handler.cancel.reason }}
+      CANCELLATION_REASON: ${{ handler.reason }}


### PR DESCRIPTION
Custom job spec: https://github.com/calculi-corp/cloudbees-automation-controller/blob/main/interfaces.adoc

1. Replaced handler.cancel.reason with handler.reason
2. Replaced handler.callback.payload with handler.payload
3. cancel handler does not write job status to CLOUDBEES_CUSTOM_JOB_STATUS. Cancel job status is controlled entirely by the execution engine.