### PR TITLE
CBP-5833:   manual-job custom handlers not using the command and args as per spec causing handler to fail with no such file found error

### DIFF
--- a/custom-job.yml
+++ b/custom-job.yml
@@ -21,7 +21,7 @@ handlers:
     args: |
       -c "
       # Make Platform API call to create workflow manual approval
-      response=$(curl --fail-with-body  -X POST \"$URL/v1/workflows/approval\" -H \"Authorization: Bearer $API_TOKEN\" -H 'Content-Type: application/json' -d '{\"instruction\": \"'\"$INSTRUCTION\"'\", \"approvers\": '[\"$APPROVERS\"]', \"disallowLaunchByUser\": '${DISALLOW_LAUNCHED_BY_USER:-false}' }') || command_failed=1
+      response=$(curl --fail-with-body  -X POST \"$URL/v1/workflows/approval\" -H \"Authorization: Bearer $API_TOKEN\" -H 'Content-Type: application/json' -d '{\"instruction\": \"'\"$INSTRUCTION\"'\", \"approvers\": [\"'$APPROVERS'\"], \"disallowLaunchByUser\": '${DISALLOW_LAUNCHED_BY_USER:-false}' }') || command_failed=1
       
       # Check curl exit code
       if [ ${command_failed:-0} -eq 1 ];


### PR DESCRIPTION
1. Used `/bin/sh` in the`command` field instead of the script itself with `-c <script block>` as the args.
2. Changed the image to curl since its needed by the handlers.
3. Passing <-c and script block> as single string to `args` which requires escaping double-quotes in the script. 
