### PR TITLE
CBP-5932   Handle `approvers` input parameter when calling `CreateManualRequest` API in `init` handler

### DIFF
--- a/custom-job.yml
+++ b/custom-job.yml
@@ -16,23 +16,23 @@ inputs:
 
 handlers:
   init:
-    uses: docker://alpine/curl:latest
+    uses: docker://esolang/jq:latest
     command: /bin/sh
     args: |
       -c "
       # Manual approval template
-      TEMPLATE='{"approvers": ($a | split(",")), "instruction": $i, "disallowLaunchByUser": $d}'
+      TEMPLATE='{\"approvers\": ($a | split(\",\")), \"instruction\": $i, \"disallowLaunchByUser\": $d}'
 
       # Build valid JSON
-      JSON_PAYLOAD=$(/usr/bin/jq -n --arg a "$APPROVERS" --arg i "$INSTRUCTION" --argjson d "${DISALLOW_LAUNCHED_BY_USER:-false}" "$TEMPLATE")
+      JSON_PAYLOAD=$(/usr/bin/jq -n --arg a \"$APPROVERS\" --arg i \"$INSTRUCTION\" --argjson d \"${DISALLOW_LAUNCHED_BY_USER:-false}\" \"$TEMPLATE\")
         
       # To avoid issue 'argument list too long' use file
-      echo "$JSON_PAYLOAD" > /tmp/content.json
+      echo \"$JSON_PAYLOAD\" > /tmp/content.json
 
       # Make Platform API call
-      response=$(curl --fail-with-body -X 'POST' "$URL/v1/workflows/approval" \
-        -H "Authorization: Bearer ${JWT}" -H 'Content-Type: application/json' -H 'Accept: application/json' \
-        --data-binary "@/tmp/content.json") || command_failed=1
+      response=$(curl --fail-with-body -X 'POST' \"$URL/v1/workflows/approval\" \
+        -H \"Authorization: Bearer ${JWT}\" -H 'Content-Type: application/json' -H 'Accept: application/json' \
+        --data-binary \"@/tmp/content.json\") || command_failed=1
 
       # Check curl exit code
       if [ ${command_failed:-0} -eq 1 ];


### PR DESCRIPTION
CBP-5932 Handle approvers input parameter when calling CreateManualRequest API in init handler
Fixed issue with wrong docker image and escaped double quotes 