### PR TITLE
CBP-5926 [BE] Allow the notification to all eligible approvers to be controlled using an input parameter to the custom job

### DIFF
--- a/custom-job.yml
+++ b/custom-job.yml
@@ -12,9 +12,11 @@ inputs:
     required: false
   disallowLaunchByUser:
     description: For separation of responsibilities, if true, then the user who launched the workflow is not allowed to approve.
+    default: false
     required: false
   notifyEligibleUsers:
     description: If true, then all users who are eligible to approve will be notified.
+    default: false
     required: false
   debug:
     description: Set to true to enable debug logging.


### PR DESCRIPTION
Changes:
- api: https://github.com/calculi-corp/api/pull/1046
- run-service: https://github.com/calculi-corp/run-service/pull/504
- manual-approval: https://github.com/cloudbees-io/manual-approval/pull/27