### PR TITLE
fix the API parameter name used from notifyAllEligibleUsers → notifyEligibleUsers

### DIFF
--- a/.cloudbees/testing/custom-job.yml
+++ b/.cloudbees/testing/custom-job.yml
@@ -1,0 +1,58 @@
+apiVersion: automation.cloudbees.io/v1alpha1
+kind: CustomJob
+name: manual approval
+description: Request manual approval from users and teams
+
+inputs:
+  approvers:
+    description: Comma separated list of approvers. Can be users or teams. If not specified, then all users who have execute permission for approval on the workflow can approve.
+    required: false
+  instructions:
+    description: Text to display in the approval prompt
+    required: false
+  disallowLaunchByUser:
+    description: For separation of responsibilities, if true, then the user who launched the workflow is not allowed to approve.
+    default: false
+    required: false
+  notifyAllEligibleUsers:
+    description: If true, then all users who are eligible to approve will be notified.
+    default: false
+    required: false
+  debug:
+    description: Set to true to enable debug logging.
+    default: false
+    required: false
+
+handlers:
+  init:
+    uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:latest
+    command: /usr/local/bin/manual-approval
+    args: --handler "init"
+    env:
+      APPROVERS: ${{inputs.approvers}}
+      INSTRUCTIONS: ${{inputs.instructions}}
+      DISALLOW_LAUNCHED_BY_USER: ${{inputs.disallowLaunchByUser}}
+      NOTIFY_ALL_ELIGIBLE_USERS: ${{inputs.notifyAllEligibleUsers}}
+      API_TOKEN: ${{ cloudbees.api.token }}
+      URL: ${{ cloudbees.api.url }}
+      DEBUG: ${{ inputs.debug }}
+
+  callback:
+    uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:latest
+    command: /usr/local/bin/manual-approval
+    args: --handler "callback"
+    env:
+      PAYLOAD: ${{ handler.payload }}
+      API_TOKEN: ${{ cloudbees.api.token }}
+      URL: ${{ cloudbees.api.url }}
+      DEBUG: ${{ inputs.debug }}
+
+  cancel:
+    uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:latest
+    command: /usr/local/bin/manual-approval
+    args: --handler "cancel"
+    env:
+      CANCELLATION_REASON: ${{ handler.reason }}
+      API_TOKEN: ${{ cloudbees.api.token }}
+      URL: ${{ cloudbees.api.url }}
+      DEBUG: ${{ inputs.debug }}

--- a/internal/manual_approval/execute.go
+++ b/internal/manual_approval/execute.go
@@ -95,11 +95,11 @@ func (k *Config) init() error {
 	}
 
 	// by default notifyAllEligibleUsers is false
-	notifyAllEligibleUsersStr := os.Getenv("NOTIFY_ALL_ELIGIBLE_USERS")
-	if notifyAllEligibleUsersStr == "" {
-		notifyAllEligibleUsersStr = "false"
+	notifyStr := os.Getenv("NOTIFY_ALL_ELIGIBLE_USERS")
+	if notifyStr == "" {
+		notifyStr = "false"
 	}
-	notifyAllEligibleUsers, err := strconv.ParseBool(notifyAllEligibleUsersStr)
+	notify, err := strconv.ParseBool(notifyStr)
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func (k *Config) init() error {
 	// Construct request body
 	body := map[string]interface{}{
 		"disallowLaunchedByUser": disallowLaunchedByUser,
-		"notifyAllEligibleUsers": notifyAllEligibleUsers,
+		"notifyEligibleUsers":    notify,
 	}
 
 	if approvers != "" {

--- a/internal/manual_approval/execute_test.go
+++ b/internal/manual_approval/execute_test.go
@@ -110,7 +110,7 @@ func Test_init(t *testing.T) {
 				require.NotNil(t, req["instructions"])
 				require.Equal(t, instructionsInput, req["instructions"].(string))
 				require.Equal(t, false, req["disallowLaunchedByUser"].(bool))
-				require.Equal(t, false, req["notifyAllEligibleUsers"].(bool))
+				require.Equal(t, false, req["notifyEligibleUsers"].(bool))
 			},
 			respGenFunc: func() (*http.Response, error) {
 				return &http.Response{
@@ -140,7 +140,7 @@ func Test_init(t *testing.T) {
 				require.NotNil(t, req["instructions"])
 				require.Equal(t, instructionsInput, req["instructions"].(string))
 				require.Equal(t, true, req["disallowLaunchedByUser"].(bool))
-				require.Equal(t, false, req["notifyAllEligibleUsers"].(bool))
+				require.Equal(t, false, req["notifyEligibleUsers"].(bool))
 			},
 			respGenFunc: func() (*http.Response, error) {
 				return &http.Response{
@@ -171,7 +171,7 @@ func Test_init(t *testing.T) {
 				require.NotNil(t, req["instructions"])
 				require.Equal(t, instructionsInput, req["instructions"].(string))
 				require.Equal(t, true, req["disallowLaunchedByUser"].(bool))
-				require.Equal(t, false, req["notifyAllEligibleUsers"].(bool))
+				require.Equal(t, false, req["notifyEligibleUsers"].(bool))
 			},
 			respGenFunc: func() (*http.Response, error) {
 				return &http.Response{
@@ -192,14 +192,14 @@ func Test_init(t *testing.T) {
 			err:    "strconv.ParseBool: parsing \"invalid boolean\": invalid syntax",
 		},
 		{
-			name: "success with notifyAllEligibleUsers",
+			name: "success with notifyEligibleUsers",
 			reqCheckFunc: func(req map[string]interface{}) {
 				require.NotNil(t, req["approvers"])
 				require.Equal(t, []interface{}{"123", "user@mail.com"}, req["approvers"])
 				require.NotNil(t, req["instructions"])
 				require.Equal(t, instructionsInput, req["instructions"].(string))
 				require.Equal(t, false, req["disallowLaunchedByUser"].(bool))
-				require.Equal(t, true, req["notifyAllEligibleUsers"].(bool))
+				require.Equal(t, true, req["notifyEligibleUsers"].(bool))
 			},
 			respGenFunc: func() (*http.Response, error) {
 				return &http.Response{
@@ -223,14 +223,14 @@ func Test_init(t *testing.T) {
 			err: "",
 		},
 		{
-			name: "success with invalid notifyAllEligibleUsers",
+			name: "success with invalid notifyEligibleUsers",
 			reqCheckFunc: func(req map[string]interface{}) {
 				require.NotNil(t, req["approvers"])
 				require.Equal(t, []interface{}{"123", "user@mail.com"}, req["approvers"])
 				require.NotNil(t, req["instructions"])
 				require.Equal(t, instructionsInput, req["instructions"].(string))
 				require.Equal(t, false, req["disallowLaunchedByUser"].(bool))
-				require.Equal(t, true, req["notifyAllEligibleUsers"].(bool))
+				require.Equal(t, true, req["notifyEligibleUsers"].(bool))
 			},
 			respGenFunc: func() (*http.Response, error) {
 				return &http.Response{
@@ -258,7 +258,7 @@ func Test_init(t *testing.T) {
 				require.NotNil(t, req["instructions"])
 				require.Equal(t, instructionsInput, req["instructions"].(string))
 				require.Equal(t, false, req["disallowLaunchedByUser"].(bool))
-				require.Equal(t, false, req["notifyAllEligibleUsers"].(bool))
+				require.Equal(t, false, req["notifyEligibleUsers"].(bool))
 			},
 			respGenFunc: func() (*http.Response, error) {
 				return &http.Response{


### PR DESCRIPTION
1. Fixed the API parameter name used from notifyAllEligibleUsers → notifyEligibleUsers
2. Added custom-job.yaml copy under `.cloudbees/testing` for testing latest preprod image