### PR TITLE
bump image version to the one built at e079e5690d1b2631db337817486d463a8f56f46e

### DIFF
--- a/custom-job.yml
+++ b/custom-job.yml
@@ -25,7 +25,7 @@ inputs:
 
 handlers:
   init:
-    uses: docker://public.ecr.aws/l7o7z1g8/custom-jobs/manual-approval:6ba9902bef7f8193c118be7020cfac76475c1a87
+    uses: docker://public.ecr.aws/l7o7z1g8/custom-jobs/manual-approval:e079e5690d1b2631db337817486d463a8f56f46e
     command: /usr/local/bin/manual-approval
     args: --handler "init"
     env:
@@ -38,7 +38,7 @@ handlers:
       DEBUG: ${{ inputs.debug }}
 
   callback:
-    uses: docker://public.ecr.aws/l7o7z1g8/custom-jobs/manual-approval:6ba9902bef7f8193c118be7020cfac76475c1a87
+    uses: docker://public.ecr.aws/l7o7z1g8/custom-jobs/manual-approval:e079e5690d1b2631db337817486d463a8f56f46e
     command: /usr/local/bin/manual-approval
     args: --handler "callback"
     env:
@@ -48,7 +48,7 @@ handlers:
       DEBUG: ${{ inputs.debug }}
 
   cancel:
-    uses: docker://public.ecr.aws/l7o7z1g8/custom-jobs/manual-approval:6ba9902bef7f8193c118be7020cfac76475c1a87
+    uses: docker://public.ecr.aws/l7o7z1g8/custom-jobs/manual-approval:e079e5690d1b2631db337817486d463a8f56f46e
     command: /usr/local/bin/manual-approval
     args: --handler "cancel"
     env:


### PR DESCRIPTION
bump image version to the one built at e079e5690d1b2631db337817486d463a8f56f46e  https://github.com/cloudbees-io/manual-approval/pull/44

- [x] Wait for https://github.com/cloudbees/saas-sre-manifests/pull/735 to be processed and merged
- [ ] Merge this PR to main
- [ ] Create new release 1.0.1 and move v1 tag to point to it