### PR TITLE
Updated manual approval custom job metadata for CBP-4963

### DIFF
--- a/.cloudbees/testing/custom-job.yml
+++ b/.cloudbees/testing/custom-job.yml
@@ -18,11 +18,17 @@ inputs:
     description: If true, then all users who are eligible to approve will be notified.
     default: false
     required: false
+  approvalInputs:
+    description: Inputs to be provided by the user when approving or rejecting the manual approval request.
+    required: false
   debug:
     description: Set to true to enable debug logging.
     default: false
     required: false
-
+outputs:
+  approvalInputs:
+    description: Input parameter values provided by the user when approving or rejecting the manual approval request.
+    value: ${{ handlers.callback.outputs.approvalInputs }}
 handlers:
   init:
     uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:latest
@@ -33,6 +39,7 @@ handlers:
       INSTRUCTIONS: ${{inputs.instructions}}
       DISALLOW_LAUNCHED_BY_USER: ${{inputs.disallowLaunchByUser}}
       NOTIFY_ALL_ELIGIBLE_USERS: ${{inputs.notifyAllEligibleUsers}}
+      INPUTS: ${{inputs.approvalInputs}}
       API_TOKEN: ${{ cloudbees.api.token }}
       URL: ${{ cloudbees.api.url }}
       DEBUG: ${{ inputs.debug }}

--- a/.cloudbees/testing/custom-job.yml
+++ b/.cloudbees/testing/custom-job.yml
@@ -19,7 +19,7 @@ inputs:
     default: false
     required: false
   approvalInputs:
-    description: Inputs to be provided by the user when approving or rejecting the manual approval request.
+    description: Inputs to be provided by the user when approving the manual approval request.
     required: false
   debug:
     description: Set to true to enable debug logging.
@@ -27,7 +27,7 @@ inputs:
     required: false
 outputs:
   approvalInputValues:
-    description: Input parameter values provided by the user when approving or rejecting the manual approval request.
+    description: Input parameter values provided by the user when approving the manual approval request.
     value: ${{ handlers.callback.outputs.approvalInputValues }}
   comments:
     description: The approver's comments

--- a/.cloudbees/testing/custom-job.yml
+++ b/.cloudbees/testing/custom-job.yml
@@ -26,9 +26,12 @@ inputs:
     default: false
     required: false
 outputs:
-  approvalInputs:
+  approvalInputValues:
     description: Input parameter values provided by the user when approving or rejecting the manual approval request.
-    value: ${{ handlers.callback.outputs.approvalInputs }}
+    value: ${{ handlers.callback.outputs.approvalInputValues }}
+  comments:
+    description: The approver's comments
+    value: ${{ handlers.callback.outputs.comments }}
 handlers:
   init:
     uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:latest

--- a/custom-job.yml
+++ b/custom-job.yml
@@ -26,9 +26,12 @@ inputs:
     default: false
     required: false
 outputs:
-  approvalInputs:
+  approvalInputValues:
     description: Input parameter values provided by the user when approving or rejecting the manual approval request.
-    value: ${{ handlers.callback.outputs.approvalInputs }}
+    value: ${{ handlers.callback.outputs.approvalInputValues }}
+  comments:
+    description: The approver's comments
+    value: ${{ handlers.callback.outputs.comments }}
 handlers:
   init:
     uses: docker://public.ecr.aws/l7o7z1g8/custom-jobs/manual-approval:e079e5690d1b2631db337817486d463a8f56f46e

--- a/custom-job.yml
+++ b/custom-job.yml
@@ -19,7 +19,7 @@ inputs:
     default: false
     required: false
   approvalInputs:
-    description: Inputs to be provided by the user when approving or rejecting the manual approval request.
+    description: Inputs to be provided by the user when approving the manual approval request.
     required: false
   debug:
     description: Set to true to enable debug logging.
@@ -27,7 +27,7 @@ inputs:
     required: false
 outputs:
   approvalInputValues:
-    description: Input parameter values provided by the user when approving or rejecting the manual approval request.
+    description: Input parameter values provided by the user when approving the manual approval request.
     value: ${{ handlers.callback.outputs.approvalInputValues }}
   comments:
     description: The approver's comments

--- a/custom-job.yml
+++ b/custom-job.yml
@@ -18,11 +18,17 @@ inputs:
     description: If true, then all users who are eligible to approve will be notified.
     default: false
     required: false
+  approvalInputs:
+    description: Inputs to be provided by the user when approving or rejecting the manual approval request.
+    required: false
   debug:
     description: Set to true to enable debug logging.
     default: false
     required: false
-
+outputs:
+  approvalInputs:
+    description: Input parameter values provided by the user when approving or rejecting the manual approval request.
+    value: ${{ handlers.callback.outputs.approvalInputs }}
 handlers:
   init:
     uses: docker://public.ecr.aws/l7o7z1g8/custom-jobs/manual-approval:e079e5690d1b2631db337817486d463a8f56f46e
@@ -33,6 +39,7 @@ handlers:
       INSTRUCTIONS: ${{inputs.instructions}}
       DISALLOW_LAUNCHED_BY_USER: ${{inputs.disallowLaunchByUser}}
       NOTIFY_ALL_ELIGIBLE_USERS: ${{inputs.notifyAllEligibleUsers}}
+      INPUTS: ${{inputs.approvalInputs}}
       API_TOKEN: ${{ cloudbees.api.token }}
       URL: ${{ cloudbees.api.url }}
       DEBUG: ${{ inputs.debug }}

--- a/internal/manual_approval/execute.go
+++ b/internal/manual_approval/execute.go
@@ -212,14 +212,17 @@ func (k *Config) callback() error {
 	}
 
 	//TODO: temporarily hard-coded input parameter values
-	outputBytes, err := json.Marshal(map[string]string{"param1": "val1", "param2": "val2"})
-	if err != nil {
-		return err
+	if debug {
+		outputBytes, err := json.Marshal(map[string]string{"param1": "val1", "param2": "val2"})
+		if err != nil {
+			return err
+		}
+		err = writeAsOutput("approvalInputValues", outputBytes)
+		if err != nil {
+			return err
+		}
 	}
-	err = writeAsOutput("approvalInputValues", outputBytes)
-	if err != nil {
-		return err
-	}
+
 	err = writeAsOutput("comments", []byte(comments))
 	if err != nil {
 		return err

--- a/internal/manual_approval/execute.go
+++ b/internal/manual_approval/execute.go
@@ -211,7 +211,19 @@ func (k *Config) callback() error {
 		return fmt.Errorf("Unexpected approval status '%s'", approvalStatus)
 	}
 
-	writeAsOutput("approvalInputs", map[string]string{"param1": "val1", "param2": "val2"})
+	//TODO: temporarily hard-coded input parameter values
+	outputBytes, err := json.Marshal(map[string]string{"param1": "val1", "param2": "val2"})
+	if err != nil {
+		return err
+	}
+	err = writeAsOutput("approvalInputValues", outputBytes)
+	if err != nil {
+		return err
+	}
+	err = writeAsOutput("comments", []byte(comments))
+	if err != nil {
+		return err
+	}
 	return writeStatus(jobStatus, "Successfully changed workflow manual approval status")
 }
 
@@ -312,18 +324,14 @@ func debugf(format string, a ...any) {
 	}
 }
 
-func writeAsOutput(name string, value map[string]string) error {
+func writeAsOutput(name string, value []byte) error {
 	outputsDir := os.Getenv("CLOUDBEES_OUTPUTS")
 	if outputsDir == "" {
 		return fmt.Errorf("CLOUDBEES_OUTPUTS environment variable missing")
 	}
 
-	outputBytes, err := json.Marshal(&value)
-	if err != nil {
-		return err
-	}
 	outputFile := filepath.Join(outputsDir, name)
-	err = os.WriteFile(outputFile, outputBytes, 0666)
+	err := os.WriteFile(outputFile, value, 0755)
 	if err != nil {
 		return fmt.Errorf("failed to write to %s: %w", outputFile, err)
 	}

--- a/internal/manual_approval/execute_test.go
+++ b/internal/manual_approval/execute_test.go
@@ -349,20 +349,21 @@ func Test_init(t *testing.T) {
 
 func Test_callback(t *testing.T) {
 	tests := []struct {
-		name         string
-		reqCheckFunc func(req map[string]interface{})
-		respGenFunc  func() (*http.Response, error)
-		env          map[string]string
-		client       *MockHttpClient
-		statusInFile string
-		output       []string
-		err          string
+		name             string
+		reqCheckFunc     func(req map[string]interface{})
+		respGenFunc      func() (*http.Response, error)
+		env              map[string]string
+		client           *MockHttpClient
+		statusInFile     string
+		commentsInOutput string
+		output           []string
+		err              string
 	}{
 		{
 			name: "success APPROVED",
 			reqCheckFunc: func(req map[string]interface{}) {
 				require.Equal(t, "UPDATE_MANUAL_APPROVAL_STATUS_APPROVED", req["status"].(string))
-				require.Equal(t, "test comments", req["comments"].(string))
+				require.Equal(t, "test comments1", req["comments"].(string))
 				require.Equal(t, "123", req["userId"].(string))
 				require.Equal(t, "testUserName", req["userName"].(string))
 				require.Equal(t, "2009-11-10T23:00:00Z", req["respondedOn"].(string))
@@ -375,14 +376,16 @@ func Test_callback(t *testing.T) {
 				}, nil
 			},
 			env: map[string]string{
-				"URL":              "http://test.com",
-				"API_TOKEN":        "test",
-				"CLOUDBEES_STATUS": "/tmp/test-status-out",
-				"PAYLOAD":          "{\"status\":\"UPDATE_MANUAL_APPROVAL_STATUS_APPROVED\",\"comments\":\"test comments\",\"userId\":\"123\",\"userName\":\"testUserName\",\"respondedOn\":\"2009-11-10T23:00:00Z\"}",
+				"URL":               "http://test.com",
+				"API_TOKEN":         "test",
+				"CLOUDBEES_STATUS":  "/tmp/test-status-out",
+				"CLOUDBEES_OUTPUTS": "/tmp/test-outputs",
+				"PAYLOAD":           "{\"status\":\"UPDATE_MANUAL_APPROVAL_STATUS_APPROVED\",\"comments\":\"test comments1\",\"userId\":\"123\",\"userName\":\"testUserName\",\"respondedOn\":\"2009-11-10T23:00:00Z\"}",
 			},
-			statusInFile: "{\"message\":\"Successfully changed workflow manual approval status\",\"status\":\"APPROVED\"}",
+			statusInFile:     "{\"message\":\"Successfully changed workflow manual approval status\",\"status\":\"APPROVED\"}",
+			commentsInOutput: "test comments1",
 			output: []string{
-				"Approved by testUserName on 2009-11-10T23:00:00Z with comments:\ntest comments\n",
+				"Approved by testUserName on 2009-11-10T23:00:00Z with comments:\ntest comments1\n",
 			},
 			err: "",
 		},
@@ -390,7 +393,7 @@ func Test_callback(t *testing.T) {
 			name: "success REJECTED",
 			reqCheckFunc: func(req map[string]interface{}) {
 				require.Equal(t, "UPDATE_MANUAL_APPROVAL_STATUS_REJECTED", req["status"].(string))
-				require.Equal(t, "test comments", req["comments"].(string))
+				require.Equal(t, "test comments2", req["comments"].(string))
 				require.Equal(t, "123", req["userId"].(string))
 				require.Equal(t, "testUserName", req["userName"].(string))
 				require.Equal(t, "2009-11-10T23:00:00Z", req["respondedOn"].(string))
@@ -403,14 +406,16 @@ func Test_callback(t *testing.T) {
 				}, nil
 			},
 			env: map[string]string{
-				"URL":              "http://test.com",
-				"API_TOKEN":        "test",
-				"CLOUDBEES_STATUS": "/tmp/test-status-out",
-				"PAYLOAD":          "{\"status\":\"UPDATE_MANUAL_APPROVAL_STATUS_REJECTED\",\"comments\":\"test comments\",\"userId\":\"123\",\"userName\":\"testUserName\",\"respondedOn\":\"2009-11-10T23:00:00Z\"}",
+				"URL":               "http://test.com",
+				"API_TOKEN":         "test",
+				"CLOUDBEES_STATUS":  "/tmp/test-status-out",
+				"CLOUDBEES_OUTPUTS": "/tmp/test-outputs",
+				"PAYLOAD":           "{\"status\":\"UPDATE_MANUAL_APPROVAL_STATUS_REJECTED\",\"comments\":\"test comments2\",\"userId\":\"123\",\"userName\":\"testUserName\",\"respondedOn\":\"2009-11-10T23:00:00Z\"}",
 			},
-			statusInFile: "{\"message\":\"Successfully changed workflow manual approval status\",\"status\":\"REJECTED\"}",
+			statusInFile:     "{\"message\":\"Successfully changed workflow manual approval status\",\"status\":\"REJECTED\"}",
+			commentsInOutput: "test comments2",
 			output: []string{
-				"Rejected by testUserName on 2009-11-10T23:00:00Z with comments:\ntest comments\n",
+				"Rejected by testUserName on 2009-11-10T23:00:00Z with comments:\ntest comments2\n",
 			},
 			err: "",
 		},
@@ -478,6 +483,10 @@ func Test_callback(t *testing.T) {
 					os.Unsetenv(k)
 				}(k)
 			}
+			outputs_dir, exists := tt.env["CLOUDBEES_OUTPUTS"]
+			if exists {
+				os.Mkdir(outputs_dir, 0755)
+			}
 
 			var testOutput []string
 
@@ -523,6 +532,9 @@ func Test_callback(t *testing.T) {
 			// Verify
 			if tt.err == "" {
 				require.NoError(t, err)
+				out, ferr := os.ReadFile(tt.env["CLOUDBEES_OUTPUTS"] + "/comments")
+				require.NoError(t, ferr)
+				require.Equal(t, tt.commentsInOutput, string(out))
 			} else {
 				require.Error(t, err)
 				require.Equal(t, tt.err, err.Error())

--- a/internal/manual_approval/execute_test.go
+++ b/internal/manual_approval/execute_test.go
@@ -486,6 +486,9 @@ func Test_callback(t *testing.T) {
 			outputs_dir, exists := tt.env["CLOUDBEES_OUTPUTS"]
 			if exists {
 				os.Mkdir(outputs_dir, 0755)
+				defer func(dir string) {
+					os.RemoveAll(dir)
+				}(outputs_dir)
 			}
 
 			var testOutput []string
@@ -532,12 +535,14 @@ func Test_callback(t *testing.T) {
 			// Verify
 			if tt.err == "" {
 				require.NoError(t, err)
-				out, ferr := os.ReadFile(tt.env["CLOUDBEES_OUTPUTS"] + "/comments")
-				require.NoError(t, ferr)
-				require.Equal(t, tt.commentsInOutput, string(out))
 			} else {
 				require.Error(t, err)
 				require.Equal(t, tt.err, err.Error())
+			}
+			if tt.commentsInOutput != "" {
+				out, ferr := os.ReadFile(tt.env["CLOUDBEES_OUTPUTS"] + "/comments")
+				require.NoError(t, ferr)
+				require.Equal(t, tt.commentsInOutput, string(out))
 			}
 
 			out, ferr := os.ReadFile(tt.env["CLOUDBEES_STATUS"])


### PR DESCRIPTION
o Added output parameters `approvalInputValues` and `comments` as per requirement to the metadata 
o Added code (with temporarily hard-coded input parameter values) to write the output parameters to $CLOUDBEES_OUTPUTS output directory