### PR TITLE
Migrate kaniko build to cb-internal-shared-actions/build@v8

### DIFF
--- a/.cloudbees/workflows/manual-approval.yaml
+++ b/.cloudbees/workflows/manual-approval.yaml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  scm-token-own: read
   id-token: write
 
 jobs:
@@ -17,43 +18,18 @@ jobs:
     - name: Get source code
       uses: cloudbees-io/checkout@v1
 
-    - name: Unit tests
-      uses: docker://golang:1.25.7-alpine3.23
-      run: |
-        go test --cover ./...
-
-    - name: Login to AWS
-      uses: cloudbees-io/configure-aws-credentials@v1
+    - id: build
+      name: Build, scan and push to ECR
+      uses: calculi-corp/cb-internal-shared-actions/build@v8
       with:
-        aws-region: us-east-1
-        role-to-assume: ${{ vars.oidc_staging_iam_role }}
-        role-duration-seconds: "3600"
-
-    - name: Configure container registry for ECR
-      uses: cloudbees-io/configure-ecr-credentials@v1
-
-    - name: Build image
-      id: build-image
-      uses: cloudbees-io/kaniko@v1
-      with:
-        destination: 020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:${{ cloudbees.scm.sha }}${{ cloudbees.scm.branch == 'main' && ',020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:latest' || ''}}
-        labels: maintainer=cbp-cd-ro-team,email=engineering@cloudbees.io
-        registry-mirrors: 020229604682.dkr.ecr.us-east-1.amazonaws.com/docker-hub
-
-    - name: Generate SLSA attestation
-      id: slsa-attestation
-      uses: calculi-corp/slsa-attestation@v1
-      with:
-        image-digest: 020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval@${{ steps.build-image.outputs.digest }}
-        aws-role-to-assume: ${{ vars.oidc_staging_iam_role }}
-        aws-region: us-east-1
-        aws-kms-alias: cbp-dev-kms-key-cosign
-
-    - name: Run TruffleHog Container Action
-      uses: cloudbees-io/trufflehog-secret-scan-container@v1
-      with:
-        image-location: 020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval
-        image-tag: ${{ cloudbees.scm.sha }}
+        go-binary-build: "true"
+        go-binary-name: manual-approval
+        kaniko-build: "true"
+        trivy-scan-container: "true"
+        registry-url: 020229604682.dkr.ecr.us-east-1.amazonaws.com
+        registry-image-name: custom-jobs/manual-approval
+        registry-type: ECR
+        oidc-iam-role: ${{ vars.oidc_staging_iam_role }}
 
     - name: Check image
       uses: docker://alpine:3.18
@@ -61,12 +37,12 @@ jobs:
         apk add -U --no-cache curl ca-certificates
         curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 >/usr/local/bin/regctl
         chmod 755 /usr/local/bin/regctl
-        
-        EXPECTED=${{ steps.build-image.outputs.digest }}
-        ACTUAL=`regctl image digest 020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:${{ cloudbees.scm.sha }}`
+
+        EXPECTED=${{ steps.build.outputs.digest }}
+        ACTUAL=`regctl image digest 020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:${{ cloudbees.version }}`
         if [ "$EXPECTED" != "$ACTUAL" ]; then
           echo "expected $EXPECTED, but got $ACTUAL"
           exit 1
         fi
-        
-        regctl image inspect 020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:${{ cloudbees.scm.sha }}
+
+        regctl image inspect 020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:${{ cloudbees.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,5 @@
-FROM golang:1.25.7-alpine3.23 AS build
-
-WORKDIR /work
-
-COPY go.mod* go.sum* ./
-
-RUN go mod download
-
-COPY . .
-
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /usr/local/bin/manual-approval main.go
-
 FROM gcr.io/distroless/static:nonroot
 
-COPY --from=build /usr/local/bin/manual-approval /usr/local/bin/manual-approval
+COPY manual-approval /usr/local/bin/manual-approval
 
 ENTRYPOINT ["/usr/local/bin/manual-approval"]


### PR DESCRIPTION
Replace the kaniko@v1 + AWS/ECR login + slsa-attestation + post-build trufflehog-scan-container pipeline with a single `calculi-corp/cb-internal-shared-actions/build@v8` (services variant) call. Refactor Dockerfile to the runtime-only template — Go binary is now built by the shared action's `go-binary-build` step. The post-build `regctl` digest-verify step is preserved.

Recipe: [`kaniko-to-v8.md`](https://github.com/cloudbees/ai-agents/blob/e7d13bb/.claude/skills/upgrade-shared-actions/recipes/kaniko-to-v8.md)

Generated by `/upgrade-shared-actions` (ai-agents@e7d13bb).