### PR TITLE
[CBP-45084] switch to build/action@v8 (action variant)

### DIFF
--- a/.cloudbees/workflows/manual-approval.yaml
+++ b/.cloudbees/workflows/manual-approval.yaml
@@ -21,7 +21,7 @@ jobs:
 
     - id: build
       name: Build, scan and push to ECR
-      uses: calculi-corp/cb-internal-shared-actions/build@v8
+      uses: calculi-corp/cb-internal-shared-actions/build/action@v8
       with:
         go-binary-build: "true"
         go-binary-name: manual-approval

--- a/.cloudbees/workflows/manual-approval.yaml
+++ b/.cloudbees/workflows/manual-approval.yaml
@@ -40,10 +40,10 @@ jobs:
         chmod 755 /usr/local/bin/regctl
 
         EXPECTED=${{ steps.build.outputs.digest }}
-        ACTUAL=`regctl image digest 020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:${{ cloudbees.version }}`
+        ACTUAL=`regctl image digest 020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:${{ cloudbees.scm.sha }}`
         if [ "$EXPECTED" != "$ACTUAL" ]; then
           echo "expected $EXPECTED, but got $ACTUAL"
           exit 1
         fi
 
-        regctl image inspect 020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:${{ cloudbees.version }}
+        regctl image inspect 020229604682.dkr.ecr.us-east-1.amazonaws.com/custom-jobs/manual-approval:${{ cloudbees.scm.sha }}


### PR DESCRIPTION
Switch this repo from `calculi-corp/cb-internal-shared-actions/build@v8`
(services variant) to `build/action@v8` (action variant) — the variant
intended for cloudbees-io action repos.

Follows the pattern Kirk established in
[cloudbees-io/configure-oci-credentials#33](https://github.com/cloudbees-io/configure-oci-credentials/pull/33).
The producer side (clean `image:${gitsha}` tag prepended to the destination
list) shipped in
[calculi-corp/cb-internal-shared-actions#123](https://github.com/calculi-corp/cb-internal-shared-actions/pull/123).

### Edits applied

- `.cloudbees/workflows/manual-approval.yaml`: `build@v8` → `build/action@v8`

### Edits NOT applied (already in good state)

- `permissions:` block already has `scm-token-org: read`.
- No `.cloudbees/testing/action.yml` in this repo.

Tracking: CBP-45084